### PR TITLE
Copying plugins inside ckeditor creates a child plugin copy

### DIFF
--- a/djangocms_text_ckeditor/cms_plugins.py
+++ b/djangocms_text_ckeditor/cms_plugins.py
@@ -537,6 +537,7 @@ class TextPlugin(CMSPluginBase):
         # save() again on the Text instance (aka obj in this context) to update mptt values (numchild, etc).
         # See this ticket for details https://github.com/divio/djangocms-text-ckeditor/issues/212
         obj.clean_plugins()
+        obj.copy_referenced_plugins()
 
     def get_action_token(self, request, obj):
         plugin_id = force_str(obj.pk)


### PR DESCRIPTION
This is a fix for [issue 504](https://github.com/django-cms/djangocms-text-ckeditor/issues/504).

With this change, every time a child plugin is copied from one text editor to another using copy-paste in the text, the child plugin will be properly copied, instead of just referencing the original child plugin. This prevents all kinds of complications down the road.