### PR TITLE
504 copy paste plugins inside ckeditor refer to same instance

### DIFF
--- a/djangocms_text_ckeditor/models.py
+++ b/djangocms_text_ckeditor/models.py
@@ -85,19 +85,24 @@ class AbstractText(CMSPlugin):
     def copy_referenced_plugins(self):
         referenced_plugins = self.get_referenced_plugins()
         if referenced_plugins:
-            plugins_ziplist = copy_plugins_to(
+            plugins_pairs = list(copy_plugins_to(
                 referenced_plugins,
                 self.placeholder,
                 to_language=self.language,
                 parent_plugin_id=self.id
-            )
-            self.post_copy(self, plugins_ziplist)
+            ))
+            self.add_existing_child_plugins_to_pairs(plugins_pairs)
+            self.post_copy(self, plugins_pairs)
 
     def get_referenced_plugins(self):
         ids_in_body = set(plugin_tags_to_id_list(self.body))
         child_plugins_ids = set(self.cmsplugin_set.all().values_list('id', flat=True))
         referenced_plugins_ids = ids_in_body - child_plugins_ids
         return CMSPlugin.objects.filter(id__in=referenced_plugins_ids)
+
+    def add_existing_child_plugins_to_pairs(self, plugins_pairs):
+        for plugin in self.cmsplugin_set.all():
+            plugins_pairs.append((plugin, plugin))
 
     def _get_inline_plugin_ids(self):
         return plugin_tags_to_id_list(self.body)

--- a/djangocms_text_ckeditor/models.py
+++ b/djangocms_text_ckeditor/models.py
@@ -3,9 +3,9 @@ from django.utils.encoding import force_str
 from django.utils.html import strip_tags
 from django.utils.text import Truncator
 from django.utils.translation import gettext_lazy as _
-from cms.utils.copy_plugins import copy_plugins_to
 
 from cms.models import CMSPlugin
+from cms.utils.copy_plugins import copy_plugins_to
 
 from . import settings
 from .html import clean_html, extract_images


### PR DESCRIPTION
This is fixing a severe bug caused by [pull request 569](https://github.com/django-cms/djangocms-text-ckeditor/pull/569). In pull request 569, after the referenced plugin is copied  successfully, the post_copy method is removing the other child plugins of the plugin we are pasting into, because the other child plugins are not inside the plugins_ziplist provided in the arguments of the post_copy method. This fix is including the existing plugins as well, so they are not touched by the post_copy method.