### PR TITLE
fix: breaking tests

### DIFF
--- a/tests/requirements/base.txt
+++ b/tests/requirements/base.txt
@@ -13,6 +13,9 @@ django-app-helper
 tox
 wheel
 
+# IMPORTANT: latest easy-thumbnails causes error since it returns with floating point, but the tests are not prepared for this and even the lib
+easy-thumbnails==2.7.1
+
 # In order to run skipped tests uncomment the next lines:
 # -e git+ssh://git@github.com/divio/djangocms-transfer.git@master#egg=djangocms-transfer
 # -e git+ssh://git@github.com/divio/djangocms-translations.git@master#egg=djangocms-translations


### PR DESCRIPTION
The test were breaking due to a version of easy-thumbnails that has a
breaking change for which our code doesn't account for. It also didn't
happened in the past, because the recent release of
easy-thumbnails==2.8.0 and since our requirements were unpinned, the
latest started to get installed into our tests and started breaking
them.

In order to fix this until we account for the backward in-compatible
change of easy-thumbnails is to switch to the last stable version of
easy-thumbnails, that we are sure will work.

- Github Issue: #584

Authored-by: Vinit Kumar <vinit.kumar@kidskonnect.nl>
Signed-off-by: Vinit Kumar <vinit.kumar@kidskonnect.nl>