### PR TITLE
Removed invalid pypi classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ CLASSIFIERS = [
     'Framework :: Django CMS :: 3.6',
     'Framework :: Django CMS :: 3.7',
     'Framework :: Django CMS :: 3.8',
-    'Framework :: Django CMS :: 3.9',
     'Topic :: Internet :: WWW/HTTP',
     'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     'Topic :: Software Development',


### PR DESCRIPTION
Removed the CMS 3.9 classifier because it's invalid.

https://pypi.org/pypi?%3Aaction=list_classifiers

https://github.com/django-cms/djangocms-text-ckeditor/runs/5482073249?check_suite_focus=true