### PR TITLE
fix: Remove excessive spaces (#531)

### DIFF
--- a/djangocms_text_ckeditor/utils.py
+++ b/djangocms_text_ckeditor/utils.py
@@ -123,7 +123,7 @@ def plugin_tags_to_admin_html(text, context):
 
 def plugin_tags_to_db(text):
     def _strip_plugin_content(obj, match):
-        return plugin_to_tag(obj)
+        return plugin_to_tag(obj).strip()
     return _plugin_tags_to_html(text, output_func=_strip_plugin_content)
 
 


### PR DESCRIPTION
Resolves #531 

Related to [PR](https://github.com/django-cms/djangocms-text-ckeditor/pull/532) and [that comment](https://github.com/django-cms/djangocms-text-ckeditor/issues/589#issuecomment-1063651636)