### PR TITLE
fix: Added fallback for ALDRYN_BOILERPLATE_NAME setting

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,6 @@
 CHANGELOG
 =========
+* fix: Added default for ALDRYN_BOILERPLATE_NAME setting
 
 3.6.0 (2018-04-11)
 ------------------

--- a/aldryn_config.py
+++ b/aldryn_config.py
@@ -30,7 +30,7 @@ class Form(forms.BaseForm):
         }
 
         # This could fail if aldryn-django-cms has not been configured yet.
-        boilerplate_name = settings['ALDRYN_BOILERPLATE_NAME']
+        boilerplate_name = settings.get('ALDRYN_BOILERPLATE_NAME', 'legacy')
 
         if data.get('content_css'):
             CKEDITOR_SETTINGS['contentsCss'] = data['content_css']


### PR DESCRIPTION
The setting ALDRYN_BOILERPLATE_NAME was always expected to be configured, add a fallback to prevent failures if it isn't.