### PR TITLE
Pinned easy-thumbnails to prevent floating point error, removed legacy aldryn setting

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+Unreleased
+----------
+* fix: Removed legacy aldryn settings
+* fix: Pinned easy-thumbnails to 2.7.1 to prevent floating point image
+  size test failures
+
 3.6.0 (2018-04-11)
 ------------------
 

--- a/aldryn_config.py
+++ b/aldryn_config.py
@@ -29,20 +29,14 @@ class Form(forms.BaseForm):
             'skin': 'moono-lisa',
         }
 
-        # This could fail if aldryn-django-cms has not been configured yet.
-        boilerplate_name = settings['ALDRYN_BOILERPLATE_NAME']
-
         if data.get('content_css'):
             CKEDITOR_SETTINGS['contentsCss'] = data['content_css']
         else:
             CKEDITOR_SETTINGS['contentsCss'] = ['/static/css/base.css']
 
+        style_set = ''
         if data.get('style_set'):
             style_set = data['style_set']
-        elif boilerplate_name == 'bootstrap3':
-            style_set = '/static/js/addons/ckeditor.wysiwyg.js'
-        else:
-            style_set = ''
 
         CKEDITOR_SETTINGS['stylesSet'] = 'default:{}'.format(style_set)
 

--- a/tests/requirements/requirements_base.txt
+++ b/tests/requirements/requirements_base.txt
@@ -12,6 +12,9 @@ coverage
 
 https://github.com/divio/django-cms/archive/release/4.0.x.zip
 
+# IMPORTANT: latest easy-thumbnails causes error since it returns with floating point, but the tests are not prepared for this and even the lib
+easy-thumbnails==2.7.1
+
 # In order to run skipped tests uncomment the next lines:
 # -e git+ssh://git@github.com/divio/djangocms-transfer.git@master#egg=djangocms-transfer
 # -e git+ssh://git@github.com/divio/djangocms-translations.git@master#egg=djangocms-translations


### PR DESCRIPTION
Test failures caused by easy-thumbnails returning a floating point number were resolved by pinning the version to 2.7.1, this change has already been brought into the 4.0.x branch, although it was not possible to cherrypick it due to other changes in the same commit

ALDRYN_TEMPLATE_NAME was removed from aldryn_django_cms, so to prevent build failures, the check for it has been removed.

Reference:
* https://github.com/django-cms/djangocms-text-ckeditor/commit/7281945d57b503defe2fedcb94849cacc6223428
* https://github.com/divio/aldryn-django-cms/commit/c26514c4c1d4fdad861ed90d5a2a3cf22fc2df6b