### PR TITLE
fix: [CMS v4] Deleted ghost plugins leave gaps in plugin tree leading to move operations failing

### DIFF
--- a/djangocms_text_ckeditor/forms.py
+++ b/djangocms_text_ckeditor/forms.py
@@ -92,9 +92,10 @@ class DeleteOnCancelForm(forms.Form):
         child_plugins = self.cleaned_data.get('child_plugins')
 
         if child_plugins:
-            child_plugins.delete()
+            for child in child_plugins:
+                child.placeholder.delete_plugin(child)
         else:
-            self.text_plugin.delete()
+            self.text_plugin.placeholder.delete_plugin(self.text_plugin)
 
 
 class TextForm(ModelForm):

--- a/tests/requirements/requirements_base.txt
+++ b/tests/requirements/requirements_base.txt
@@ -11,7 +11,7 @@ tox
 https://github.com/django-cms/django-cms/tarball/develop-4#egg=django-cms
 
 # IMPORTANT: latest easy-thumbnails causes error since it returns with floating point, but the tests are not prepared for this and even the lib
-easy-thumbnails==2.7.1
+easy-thumbnails
 
 # In order to run skipped tests uncomment the next lines:
 # -e git+ssh://git@github.com/divio/djangocms-transfer.git@master#egg=djangocms-transfer

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -108,6 +108,7 @@ HELPER_SETTINGS = {
         'DummyLinkPlugin': {'text_field_child_label': 'label'},
     },
     'DEFAULT_AUTO_FIELD': 'django.db.models.AutoField',
+    'CMS_CONFIRM_VERSION4': True,
 }
 
 HELPER_SETTINGS['MIGRATION_MODULES'] = DisableMigrations()

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -19,7 +19,7 @@ class MigrationTestCase(TestCase):
         }
 
         try:
-            call_command('makemigrations', **options)
+            call_command('makemigrations', 'djangocms_text_ckeditor', **options)
         except SystemExit as e:
             status_code = str(e)
         else:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -521,7 +521,7 @@ class PluginActionsTestCase(BaseTestCase):
             body="I'm the first",
         )
         text_plugin_class = text_plugin.get_plugin_class_instance()
-        child_plugin = self._add_child_plugin(text_plugin)
+        child_plugin = self._add_child_plugin(text_plugin, 'LinkPlugin')
         text_plugin = self.add_plugin_to_text(text_plugin, child_plugin)
 
         with self.login_user_context(self.get_superuser()):


### PR DESCRIPTION
This PR fixes https://github.com/django-cms/django-cms/issues/7391 .  It is specifically designed for the `support/4.0.x` branch. Alternatively, use `djangocms-text-ckeditor>=5.1.2` which natively supports django CMS versions 4.0.x and 4.1.x.

# Inconsistent behaviour when reordering plugins

![disable-moving](https://user-images.githubusercontent.com/16904477/191203585-af1cf6ec-3873-4877-b424-01353b4bba8a.gif)

# Reason

When cancelling creating the Text Plugin djangocms-text-ckeditor deletes "ghost" plugin it creates (to be able to allow child plugins) **without** using the django CMS V4 placeholder api. This leaves a gap in the plugin tree. Django CMS v4 internal plugin tree code assumes all child plugins being consecutively positioned right after the parent plugin to allow to move them. The gap breaks the assumption and the move fails. After a second move operation the tree assumes the plugin already is at the position it is being moved to. Any move attempt fails.

Plugin trees might remain broken.

# Solution

Using the cms v4 placeholder api automatically takes care of any gaps and closes them.

# Extension

Then creating the ghost plugin djangocms-text-ckeditor replicates the CMS v4 internal code. This pr could be amended by replacing the code duplication by also using cms' placeholder api to create the ghost plugin. The step can be added to the pr upon request of the reviewers.

# Repairing broken plugin trees

The brave can try repairing already broken plugin trees at their own risk using https://github.com/fsbraun/djangocms4-utilities