### PR TITLE
Fix pending migration implied by Django 4.0 changes (#634)

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 17.x]
+        node-version: [16.x]
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}

--- a/djangocms_text_ckeditor/migrations/0005_alter_text_cmsplugin_ptr.py
+++ b/djangocms_text_ckeditor/migrations/0005_alter_text_cmsplugin_ptr.py
@@ -1,0 +1,18 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cms', '0022_auto_20180620_1551'),
+        ('djangocms_text_ckeditor', '0004_auto_20160706_1339'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='text',
+            name='cmsplugin_ptr',
+            field=models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, parent_link=True, primary_key=True, related_name='%(app_label)s_%(class)s', serialize=False, to='cms.cmsplugin'),
+        ),
+    ]

--- a/tests/requirements/base.txt
+++ b/tests/requirements/base.txt
@@ -1,5 +1,5 @@
 # requirements from setup.py
-django-filer>=1.4.0,<2.1
+django-filer>=1.4.0
 djangocms-picture>=2.1.0
 djangocms-link>=2.2.1
 django-polymorphic>=2.0.3

--- a/tests/requirements/base.txt
+++ b/tests/requirements/base.txt
@@ -1,5 +1,5 @@
 # requirements from setup.py
-django-filer>=1.4.0
+django-filer>=1.4.0,<2.1
 djangocms-picture>=2.1.0
 djangocms-link>=2.2.1
 django-polymorphic>=2.0.3


### PR DESCRIPTION
- Added new migration as expected by Django 4.0
- Pinned django-filer>=1.4.0,<2.1 in tests base requirements because it is incompatible with supported Django versions from tox config

I've launched tox on my work and it runned almost well but failed on environments with Django 3.2 because of missing migrations from some dependencies (filer, easy_thumbnails), possibly because of the same bug we are fixing here.

I'm attaching the full tox run output here so you can check yourself without to run it yet:

[tox_log_output.txt](https://github.com/django-cms/djangocms-text-ckeditor/files/10045810/tox_log_output.txt)

Also i'm not totally sure about my migration which have a dependency to the last CMS one, but i saw there is no CMS migration dependency in any of the djangocms-text-ckeditor migrations, maybe you were removing them for a reason, or this is normal, i don't know..

Let me know if you want me to remove it if it is not expected.
