### PR TITLE
fix: Issue #641 created by typo in widgets.py

### DIFF
--- a/djangocms_text_ckeditor/widgets.py
+++ b/djangocms_text_ckeditor/widgets.py
@@ -110,7 +110,7 @@ class TextEditorWidget(forms.Textarea):
             'placeholder_id': self.placeholder.pk if self.placeholder else None,
             'render_plugin_url': self.render_plugin_url or '',
             'add_plugin_url': admin_reverse(cms_placeholder_add_plugin) if self.placeholder else '',
-            'clancel_plugin_url': self.cancel_url or '',
+            'cancel_plugin_url': self.cancel_url or '',
             'delete_on_cancel': self.delete_on_cancel or False,
             'action_token': self.action_token or '',
             'lang': {


### PR DESCRIPTION
## Description

This PR fixes issue #641. 

I traced it back to a simple typo in `widgets.py`which left the `cancel_plugin_url` property in the editor's setting empty (but filled the unused property `clancel_plugin_url`).

In effect, the cmspluings' `plugin.js` in turn creates a POST request with empty content to the edit endpoint (where the form was originally loaded), effectively deleting the text as opposed to the newly created plugins. The correct behavior would call the `cancel_plugin_url` endpoint which in turn deletes any added child plugins when cancel is pressed.

## References

* #641 
