### PR TITLE
feat: Bump to 5.1.4

### DIFF
--- a/djangocms_text_ckeditor/__init__.py
+++ b/djangocms_text_ckeditor/__init__.py
@@ -16,6 +16,6 @@ Release logic:
 10. Publish the release when ready
 11. Github actions will publish the new package to pypi
 """
-__version__ = '5.1.3'
+__version__ = '5.1.4'
 
 default_app_config = 'djangocms_text_ckeditor.apps.TextCkeditorConfig'


### PR DESCRIPTION
This PR prepares the release of version 5.1.4:

* fix: test suite for Django 2.2 by @fsbraun in https://github.com/django-cms/djangocms-text-ckeditor/pull/650
* fix: Remove legacy code from Django pre 1.4 by @fsbraun in https://github.com/django-cms/djangocms-text-ckeditor/pull/651
* fix: Issue #641 created by typo in widgets.py by @fsbraun in https://github.com/django-cms/djangocms-text-ckeditor/pull/652
* Feature/issue 648 unable to unlink by @jrief in https://github.com/django-cms/djangocms-text-ckeditor/pull/649
