### PR TITLE
Remove Flash plugin in the default settings

### DIFF
--- a/djangocms_text_ckeditor/settings.py
+++ b/djangocms_text_ckeditor/settings.py
@@ -1,3 +1,5 @@
+from typing import Dict, List, Union
+
 from django.conf import settings
 from django.templatetags.static import static
 from django.utils.translation import gettext_lazy as _
@@ -6,12 +8,13 @@ from django.utils.translation import gettext_lazy as _
 # See http://docs.cksource.com/ckeditor_api/symbols/CKEDITOR.config.html
 # for all settings
 
-CKEDITOR_SETTINGS = {
+CKEDITOR_SETTINGS: Dict[str, Union[str, List]] = {
     'language': '{{ language }}',
     'toolbar': 'CMS',
     'skin': 'moono-lisa',
     'baseFloatZIndex': 10000000,
     'toolbarCanCollapse': False,
+    'removePlugins': ['flash'],
     **getattr(settings, 'CKEDITOR_SETTINGS', {}),
 }
 


### PR DESCRIPTION
This avoids an error message about the deprecated Flash plugin in the JS console.