### PR TITLE
fix: Allow for request-free context objects for testing purposes

### DIFF
--- a/djangocms_text_ckeditor/cms_plugins.py
+++ b/djangocms_text_ckeditor/cms_plugins.py
@@ -551,7 +551,7 @@ class TextPlugin(CMSPluginBase):
         )
 
     def render(self, context, instance, placeholder):
-        if self.inline_editing_active(context["request"]):
+        if self.inline_editing_active(context.get("request")):
             ckeditor_settings = self.get_editor_widget(
                 context["request"], self.get_plugins(instance), instance
             ).get_ckeditor_settings(get_language().split("-")[0])


### PR DESCRIPTION
While for any django CMS installation the request object is part of a plugin's context, this is not the case for all testing scenarios.

To ease testing this PR allows rendering of text plugins without the request object being part of the context.