### PR TITLE
Support djangocms-picture 2.0.0 and higher in create_picture_plugin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,8 @@ jobs:
         ]
         exclude:
           - python-version: 3.7
+            requirements-file: dj32_cms41.txt
+          - python-version: 3.7
             requirements-file: dj40_cms311.txt
           - python-version: 3.7
             requirements-file: dj40_cms41.txt

--- a/djangocms_text_ckeditor/picture_save.py
+++ b/djangocms_text_ckeditor/picture_save.py
@@ -1,6 +1,3 @@
-import os
-
-from django.conf import settings
 from django.core.files.base import ContentFile
 
 from cms.models.pluginmodel import CMSPlugin

--- a/djangocms_text_ckeditor/picture_save.py
+++ b/djangocms_text_ckeditor/picture_save.py
@@ -1,6 +1,7 @@
 import os
 
 from django.conf import settings
+from django.core.files.base import ContentFile
 
 from cms.models.pluginmodel import CMSPlugin
 
@@ -17,13 +18,14 @@ def create_picture_plugin(filename, file, parent_plugin, **kwargs):
     pic.position = CMSPlugin.objects.filter(parent=parent_plugin).count()
     pic.language = parent_plugin.language
     pic.plugin_type = 'PicturePlugin'
-    path = pic.get_media_path(filename)
-    full_path = os.path.join(settings.MEDIA_ROOT, path)
-    if not os.path.exists(os.path.dirname(full_path)):
-        os.makedirs(os.path.dirname(full_path))
-    pic.image = path
-    f = open(full_path, 'wb')
-    f.write(file.read())
-    f.close()
+
+    # Set the FilerImageField value.
+    from filer.settings import FILER_IMAGE_MODEL
+    from filer.utils.loader import load_model
+    image_class = load_model(FILER_IMAGE_MODEL)
+    image_obj = image_class(file=ContentFile(file.read(), name=filename))
+    image_obj.save()
+    pic.picture = image_obj
+
     pic.save()
     return pic

--- a/djangocms_text_ckeditor/picture_save.py
+++ b/djangocms_text_ckeditor/picture_save.py
@@ -4,10 +4,7 @@ from cms.models.pluginmodel import CMSPlugin
 
 
 def create_picture_plugin(filename, file, parent_plugin, **kwargs):
-    try:
-        from djangocms_picture.models import Picture
-    except ImportError:
-        from cms.plugins.picture.models import Picture
+    from djangocms_picture.models import Picture
 
     pic = Picture()
     pic.placeholder = parent_plugin.placeholder

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -4,6 +4,7 @@ import re
 import unittest
 from urllib.parse import unquote
 
+from django.conf import settings
 from django.contrib import admin
 from django.contrib.auth import get_permission_codename
 from django.contrib.auth.models import Permission
@@ -40,11 +41,7 @@ except ImportError:
     HAS_DJANGOCMS_TRANSLATIONS = False
 
 
-try:
-    import djangocms_picture  # noqa
-    HAS_DJANGOCMS_PICTURE = True
-except ImportError:
-    HAS_DJANGOCMS_PICTURE = False
+HAS_DJANGOCMS_PICTURE = "djangocms_picture" in settings.INSTALLED_APPS
 
 
 class PluginActionsTestCase(TestFixture, BaseTestCase):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1109,7 +1109,7 @@ class DjangoCMSPictureIntegrationTestCase(TestFixture, BaseTestCase):
         from djangocms_picture.models import Picture
         picture_plugin = Picture.objects.order_by('-id')[0]
         self.assertEqual(picture_plugin.parent.id, text_plugin.id)
-        self.assertEqual(
+        self.assertHTMLEqual(
             text_plugin.body,
             '<cms-plugin alt="Image - unnamed file " title="Image - unnamed file" id="{}"></cms-plugin>'.format(
                 picture_plugin.id,


### PR DESCRIPTION
djangocms-picture 2.0.0 switched to a filer reference to store the image so the helper must create a filer image instance

Refs #642 