### PR TITLE
fix: Let CKEditor decide on size of its panels

### DIFF
--- a/djangocms_text_ckeditor/static/djangocms_text_ckeditor/css/cms.ckeditor.css
+++ b/djangocms_text_ckeditor/static/djangocms_text_ckeditor/css/cms.ckeditor.css
@@ -83,7 +83,6 @@
 /* scrollable dropdowns on touch */
 .cke_panel {
     overflow-y: auto !important;
-    height: auto !important;
     max-height: 300px !important;
 
     -webkit-overflow-scrolling: touch !important;


### PR DESCRIPTION
This PR fixes #673 

New CKEditor 4 revisions set their panel height using JS. The `height: auto !important` style is not necessary for panels.